### PR TITLE
2.1 - Replace significant properties for film

### DIFF
--- a/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/descriptive/dc+schema.xml
+++ b/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/descriptive/dc+schema.xml
@@ -34,6 +34,7 @@
   <dcterms:rightsHolder>© dummyorganisatie</dcterms:rightsHolder>
 
   <!-- IE type -->
+  <dcterms:type>SilentFilm</dcterms:type>
   <dcterms:format>film</dcterms:format>
 
   <!-- VIAA licenses for the resource -->

--- a/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/preservation/premis.xml
+++ b/2.1/film_standard_mkv/uuid-2746e598-75cd-47b5-9a3e-8df18e98bb95/metadata/preservation/premis.xml
@@ -107,67 +107,33 @@
       <premis:objectIdentifierType>Batch-ID</premis:objectIdentifierType>
       <premis:objectIdentifierValue>FLMB20</premis:objectIdentifierValue>
     </premis:objectIdentifier>
-    <premis:objectIdentifier>
-      <premis:objectIdentifierType>Barcode-image-reels</premis:objectIdentifierType>
-      <premis:objectIdentifierValue>AFLM_FEL_001392</premis:objectIdentifierValue>
-    </premis:objectIdentifier>
 
     <premis:significantProperties>
-      <premis:significantPropertiesType>Projection-speed</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>18 f/s</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>CP-evaluation</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>4 interesting, HR digitisation</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Image-or-sound</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>image</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Aspect-ratio</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>1:37</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Number-of-reels</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>1</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Preservation-problems</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>Base Scratching remarks: Light scratches, lines and
-        stripes. Some cables.\nvinegar date: 2021-06-30 pH value:PH 4.8</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Film-base</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>acetate</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Subtitles-present</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>no</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Silent-or-spoken-movie</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>Silent Movie</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesType>Color-or-Black-and-white</premis:significantPropertiesType>
-      <premis:significantPropertiesValue>B/W and Color</premis:significantPropertiesValue>
-    </premis:significantProperties>
-    <premis:significantProperties>
-      <premis:significantPropertiesExtension xmlns:schema='https://schema.org'>
-        <schema:duration>0:04:55</schema:duration>
-        <schema:material>Original positive</schema:material>
-        <schema:size>
-          <schema:unitCode>MTR</schema:unitCode>
-          <schema:QuantitativeValue>135</schema:QuantitativeValue>
-        </schema:size>
+      <premis:significantPropertiesExtension xmlns="https://data.hetarchief.be/ns/sip/">
+
+        <numberOfReels>1</numberOfReels>
+        <inLanguage>Silent Movie</inLanguage>
+
+        <storedAt>
+          <imageReel>
+            <identifier>AFLM_FEL_001392</identifier>
+     
+            <coloringType>bandw</coloringType> 
+            <coloringType>color</coloringType> 
+
+            <material>acetate</material>
+            <preservationProblem>Base Scratching remarks: Light scratches, lines and stripes. Some cables.\nvinegar date: 2021-06-30 pH value:PH 4.8</preservationProblem>
+
+            <medium>8mmfilm</medium>
+
+            <aspectRatio>1:37</aspectRatio>
+
+            <stockType>Original positive</stockType>
+          </imageReel>
+        </storedAt>
+
       </premis:significantPropertiesExtension>
-
     </premis:significantProperties>
-
-    <premis:storage>
-      <premis:storageMedium>8mmfilm</premis:storageMedium>
-    </premis:storage>
 
     <!-- relationship between representation and its IE -->
     <premis:relationship>


### PR DESCRIPTION
> [!NOTE]
>  This PR is a copy of https://github.com/viaacode/documentation/pull/176. It is moved to here as the SIP samples were moved to this repository.

This is a first attempt at replacing the `significantProperties` key/value pairs with a well defined specification. Before doing the changes to the spec itself, I first want to do them to the film SIP sample as it's easier to iterate on and is needed for the parsing for SIP which is currently in progress.

The idea is to place a `haObj:CarrierRepresentation`, `haDes:ImageReel`or `haDes:AudioReel` inside the `premis:significantPropertiesExtension`. That way the properties for those elements are cleanly separated. The image reel and audio reel elements can be repeated if required.

(Take a break here from this comment and have a look at the changes)

Most properties can easily be translated into existing properties from the datamodels. One property that is not as trivial is "image/sound" which can have four values. I propose to translate it as follows: E.g. "image without sound" is mapped into 

inside `dc+schema.xml`
```xml
<dcterms:type>sound film</dcterms:type>
```

inside `premis.xml`:
```xml
<premis:significantPropertiesExtension>
	<haDes:CarrierRepresentation>
		<haDes:hasMissingAudioReels>true</haDes:hasMissingAudioReels>
	</haDes:CarrierRepresentation>
</premis:significantPropertiesExtension>
```

This table shows how to map each of the possible values:

| registratietool     | SIP                              |
| ------------------- | -------------------------------- |
| image               | silent film                      |
| image without sound | hasMissingAudioReels, sound film |
| sound without image | hasMissingImageReels, sound film |
| image with sound    | sound film                       |

> [!IMPORTANT]
> Important to note is that this requires a small change from the registration tool because this mapping requires changing `dc+schema.xml`.

## TODO

The following items are open:
- [x] Decide where to put the IE class (currently under `dcterms:type`)
- [x] Document the changes is the SIP spec.
- [ ] Validate the changed document with the PREMIS xsd