### PR TITLE
Apply commons ip validator to all 2.1 sips

### DIFF
--- a/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/METS.xml
+++ b/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/METS.xml
@@ -21,40 +21,40 @@
 
     <!-- ref to descriptive metadata about IE: DCTERMS format -->
     <dmdSec ID="uuid-3936403d-133f-4765-b3b9-0a46df28db17">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="./metadata/descriptive/dc+schema.xml" MIMETYPE="text/xml" SIZE="931" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="2a4ae1a152ab3a8298a407564bb63a69" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="./metadata/descriptive/dc+schema.xml" MIMETYPE="text/xml" SIZE="4033" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="d80df5d35b9c3ace0b07b82c988990d2" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->
     <amdSec>
         <digiprovMD ID="uuid-e2dcd7c5-5fad-4bcd-a7c7-762b0be75d0f">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="1437" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="9291ae8789771a29a5f6105be468f5cd" CHECKSUMTYPE="MD5"/>
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="7468" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="9291ae8789771a29a5f6105be468f5cd" CHECKSUMTYPE="MD5"/>
         </digiprovMD>
     </amdSec>
 
     <!-- file section -->
     <fileSec ID="uuid-b8e1e265-7003-42e4-8c33-3fc95122d4f4">
         <fileGrp USE="Representations/representation_1" ID="uuid-A0A670BA-0E14-40E6-BCE0-62FC42D8B4A6">
-            <file ID="uuid-ba89c101-109a-4fe3-a4ed-0c276b20e14c" MIMETYPE="text/xml" SIZE="2769" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="7f01ec2ff543146c748c9db67e4d065c" CHECKSUMTYPE="MD5">
+            <file ID="uuid-ba89c101-109a-4fe3-a4ed-0c276b20e14c" MIMETYPE="text/xml" SIZE="2530" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="c9fe36c46ad03ccf2f59be743d174f99" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_1/METS.xml"/>
             </file>
         </fileGrp>
         <fileGrp USE="Representations/representation_2" ID="uuid-93CB5D95-A091-4EAF-94B0-82B140510BE0">
-            <file ID="uuid-95f963f6-9939-4821-958b-4393051111dc" MIMETYPE="text/xml" SIZE="2772" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="6254cf675485c3b228d387caeef781a2" CHECKSUMTYPE="MD5">
+            <file ID="uuid-95f963f6-9939-4821-958b-4393051111dc" MIMETYPE="text/xml" SIZE="2508" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="b9efbfb400a5ee7c3c5d74e6823fdc55" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_2/METS.xml"/>
             </file>
         </fileGrp>
         <fileGrp USE="Representations/representation_3" ID="uuid-8DA59BD2-2B13-4317-8C6C-BCBED669D0F6">
-            <file ID="uuid-f5614ba7-68d6-449c-8ba0-ef652f63d74d" MIMETYPE="text/xml" SIZE="2332" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="f2dcab3149593cc33edc4147f9dee995" CHECKSUMTYPE="MD5">
+            <file ID="uuid-f5614ba7-68d6-449c-8ba0-ef652f63d74d" MIMETYPE="text/xml" SIZE="2486" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="e272b1aaa7190cd8bb3723675bee3036" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_3/METS.xml"/>
             </file>
         </fileGrp>
         <fileGrp USE="Representations/representation_4" ID="uuid-237899F0-1C25-4DAC-BFA4-BAFC156714BB">
-            <file ID="uuid-0c30e685-3e3a-4a34-9448-6e6afd182637" MIMETYPE="text/xml" SIZE="7127" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="54b241ae947fe7bedf3cb3376f7af591" CHECKSUMTYPE="MD5">
+            <file ID="uuid-0c30e685-3e3a-4a34-9448-6e6afd182637" MIMETYPE="text/xml" SIZE="7282" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="37727d6a214aabcdd97cbf500466ed62" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_4/METS.xml"/>
             </file>
         </fileGrp>
         <fileGrp USE="Representations/representation_5" ID="uuid-fde9e70a-806b-11ed-af79-7e92631d7d27">
-            <file ID="uuid-e37d0b84-38ae-4066-890b-eaca885fe006" MIMETYPE="text/xml" SIZE="2332" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="b5547a1c9f7b0a5bbb558594d0c6b13e" CHECKSUMTYPE="MD5">
+            <file ID="uuid-e37d0b84-38ae-4066-890b-eaca885fe006" MIMETYPE="text/xml" SIZE="2486" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="c0390e6718f30a485754171024a02c5d" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_5/METS.xml"/>
             </file>
         </fileGrp>

--- a/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_1/METS.xml
+++ b/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_1/METS.xml
@@ -9,8 +9,8 @@
     <amdSec>
         <digiprovMD ID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4782"
-                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="b0cf9991f43609b1d79ea1aa64ae246b"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4818"
+                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="cb95893497b53736d82636066c8ef1c1"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>

--- a/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_2/METS.xml
+++ b/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_2/METS.xml
@@ -9,8 +9,8 @@
     <amdSec>
         <digiprovMD ID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4782"
-                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="42aa9e8a0b902d2afa398b7e14df4ed3"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4821"
+                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="00f094d7b762eb47a311d777d7dc028d"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>

--- a/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_3/METS.xml
+++ b/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_3/METS.xml
@@ -9,8 +9,8 @@
     <amdSec>
         <digiprovMD ID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4782"
-                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="b79ac0d5ab82289b8f9a4666bab028e8"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4798"
+                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="e833b8fbd492507ec3b932014c85db65"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>

--- a/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_4/METS.xml
+++ b/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_4/METS.xml
@@ -9,8 +9,8 @@
     <amdSec>
         <digiprovMD ID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4782"
-                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="efa038a52d729f78482c88468cf2e494"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="26208"
+                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="0551a04ddbedb41b4b2a53c64b7fefd5"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>

--- a/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_5/METS.xml
+++ b/2.1/2D_fa307608-35c3-11ed-9243-7e92631d7d27/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_5/METS.xml
@@ -9,8 +9,8 @@
     <amdSec>
         <digiprovMD ID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4782"
-                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="435e65708384f4db3f4477a57b349598"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4799"
+                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="dbadc081d13a5414c10eea222d5064ac"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>

--- a/2.1/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/uuid-de61d4af-d19c-4cc7-864d-55573875b438/METS.xml
+++ b/2.1/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/uuid-de61d4af-d19c-4cc7-864d-55573875b438/METS.xml
@@ -21,13 +21,13 @@
 
     <!-- ref to descriptive metadata about IE: DCTERMS format -->
     <dmdSec ID="uuid-3936403d-133f-4765-b3b9-0a46df28db17">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="./metadata/descriptive/dc+schema.xml" MIMETYPE="text/xml" SIZE="931" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="782f39004275471de67f66b923a019f1" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="./metadata/descriptive/dc+schema.xml" MIMETYPE="text/xml" SIZE="4305" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="a45153beef15efb8ea6bf8df8eca937e" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->
     <amdSec>
         <digiprovMD ID="uuid-e2dcd7c5-5fad-4bcd-a7c7-762b0be75d0f">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="1437" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="c90107659faf2f5e9671683dbdf1f654" CHECKSUMTYPE="MD5"/>
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="11376" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="80a16a74c4135c59d549ce935a60f324" CHECKSUMTYPE="MD5"/>
         </digiprovMD>
     </amdSec>
 
@@ -35,22 +35,22 @@
     <fileSec ID="uuid-b8e1e265-7003-42e4-8c33-3fc95122d4f4">
 
         <fileGrp USE="Representations/representation_1" ID="uuid-A0A670BA-0E14-40E6-BCE0-62FC42D8B4A6">
-            <file ID="uuid-ba89c101-109a-4fe3-a4ed-0c276b20e14c" MIMETYPE="text/xml" SIZE="2343" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="182b576423c381ff45517ae58638b970" CHECKSUMTYPE="MD5">
+            <file ID="uuid-ba89c101-109a-4fe3-a4ed-0c276b20e14c" MIMETYPE="text/xml" SIZE="2460" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="7f59df4ea54e3636d1e25fbb529b5581" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_1/METS.xml"/>
             </file>
         </fileGrp>
         <fileGrp USE="Representations/representation_2" ID="uuid-93CB5D95-A091-4EAF-94B0-82B140510BE0">
-            <file ID="uuid-95f963f6-9939-4821-958b-4393051111dc" MIMETYPE="text/xml" SIZE="3116" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="d1824865b656044d49b3670d4d7016a9" CHECKSUMTYPE="MD5">
+            <file ID="uuid-95f963f6-9939-4821-958b-4393051111dc" MIMETYPE="text/xml" SIZE="3222" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="1f13e110b7c0e11c62622afbab053576" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_2/METS.xml"/>
             </file>
         </fileGrp>
         <fileGrp USE="Representations/representation_3" ID="uuid-8DA59BD2-2B13-4317-8C6C-BCBED669D0F6">
-            <file ID="uuid-f5614ba7-68d6-449c-8ba0-ef652f63d74d" MIMETYPE="text/xml" SIZE="3066" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="de133f0eea788278ca3d67297051ae73" CHECKSUMTYPE="MD5">
+            <file ID="uuid-f5614ba7-68d6-449c-8ba0-ef652f63d74d" MIMETYPE="text/xml" SIZE="3188" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="286cd30d6b0e0b27d485e572023ff734" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_3/METS.xml"/>
             </file>
         </fileGrp>
         <fileGrp USE="Representations/representation_4" ID="uuid-237899F0-1C25-4DAC-BFA4-BAFC156714BB">
-            <file ID="uuid-0c30e685-3e3a-4a34-9448-6e6afd182637" MIMETYPE="text/xml" SIZE="3056" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="2915b124053b1435b2753365fcaa4095" CHECKSUMTYPE="MD5">
+            <file ID="uuid-0c30e685-3e3a-4a34-9448-6e6afd182637" MIMETYPE="text/xml" SIZE="3162" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="d838cce9e5ad5f97fa463f9fc94c09aa" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_4/METS.xml"/>
             </file>
         </fileGrp>

--- a/2.1/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_1/METS.xml
+++ b/2.1/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_1/METS.xml
@@ -9,15 +9,15 @@
     <amdSec>
         <digiprovMD ID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4782"
-                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="76d8cbbbcca24a6b41211ba60aa7b9f7"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="5288"
+                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="356f8611e64560efa97e737d741b77fd"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>
 
     <fileSec ID="uuid-170f9654-bf8d-45df-8451-48d6203b9f03">
         <fileGrp USE="data" ID="uuid-d020d7d1-f258-40af-8788-04cf62a0032b">
-            <file ID="uuid-67757d90-2227-11ed-84ee-7e92631d7d28" MIMETYPE="model/obj" SIZE="1735648"
+            <file ID="uuid-67757d90-2227-11ed-84ee-7e92631d7d28" MIMETYPE="model/obj" SIZE="0"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="d41d8cd98f00b204e9800998ecf8427e"
                 CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple"

--- a/2.1/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_2/METS.xml
+++ b/2.1/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_2/METS.xml
@@ -9,28 +9,28 @@
     <amdSec>
         <digiprovMD ID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4782"
-                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="374b2518ad28816f1295b90c2dab7ebf"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="10640"
+                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="9d14b065c0ab3761fc869d99340829d2"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>
 
     <fileSec ID="uuid-170f9654-bf8d-45df-8451-48d6203b9f03">
         <fileGrp USE="data" ID="uuid-d020d7d1-f258-40af-8788-04cf62a0032b">
-            <file ID="uuid-67757d90-2227-11ed-84ee-7e92631d7d28" MIMETYPE="model/obj" SIZE="1735648"
+            <file ID="uuid-67757d90-2227-11ed-84ee-7e92631d7d28" MIMETYPE="model/obj" SIZE="0"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="d41d8cd98f00b204e9800998ecf8427e"
                 CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple"
                     xlink:href="./data/qv3bz95m19_ARCH_OBJ.OBJ" />
             </file>
-            <file ID="uuid-6df65478-2227-11ed-9b8f-7e92631d7d28" MIMETYPE="model/mtl" SIZE="1735648"
+            <file ID="uuid-6df65478-2227-11ed-9b8f-7e92631d7d28" MIMETYPE="model/mtl" SIZE="0"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="d41d8cd98f00b204e9800998ecf8427e"
                 CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple"
                     xlink:href="./data/qv3bz95m19_ARCH_MTL.MTL" />
             </file>
             <file ID="uuid-73ca78ac-2227-11ed-a848-7e92631d7d28" MIMETYPE="image/tiff"
-                SIZE="1735648" CREATED="2022-02-16T10:02:37.009+02:00"
+                SIZE="0" CREATED="2022-02-16T10:02:37.009+02:00"
                 CHECKSUM="d41d8cd98f00b204e9800998ecf8427e" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple"
                     xlink:href="./data/qv3bz95m19_ARCH_TIFF_COLOR.TIFF" />

--- a/2.1/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_3/METS.xml
+++ b/2.1/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_3/METS.xml
@@ -9,25 +9,25 @@
     <amdSec>
         <digiprovMD ID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4782"
-                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="f449352483751502c8add94b4c45206d"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="10636"
+                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="cb363b7df2cb6fac1609dec1e00288d7"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>
 
     <fileSec ID="uuid-170f9654-bf8d-45df-8451-48d6203b9f03">
         <fileGrp USE="data" ID="uuid-d020d7d1-f258-40af-8788-04cf62a0032b">
-            <file ID="uuid-d653bbfe-2228-11ed-86a9-7e92631d7d28" MIMETYPE="model/obj" SIZE="1735648"
+            <file ID="uuid-d653bbfe-2228-11ed-86a9-7e92631d7d28" MIMETYPE="model/obj" SIZE="0"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="d41d8cd98f00b204e9800998ecf8427e"
                 CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./data/qv3bz95m19_VER_OBJ.OBJ" />
             </file>
-            <file ID="uuid-e03f9af2-2228-11ed-b370-7e92631d7d28" MIMETYPE="model/mtl" SIZE="1735648"
+            <file ID="uuid-e03f9af2-2228-11ed-b370-7e92631d7d28" MIMETYPE="model/mtl" SIZE="0"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="d41d8cd98f00b204e9800998ecf8427e"
                 CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./data/qv3bz95m19_VER_MTL.MTL" />
             </file>
-            <file ID="uuid-e5dd9dec-2228-11ed-8871-7e92631d7d28" MIMETYPE="image/bmp" SIZE="1735648"
+            <file ID="uuid-e5dd9dec-2228-11ed-8871-7e92631d7d28" MIMETYPE="image/bmp" SIZE="0"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="d41d8cd98f00b204e9800998ecf8427e"
                 CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple"

--- a/2.1/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_4/METS.xml
+++ b/2.1/3D_3d4bd7ca-38c6-11ed-95f2-7e92631d7d28/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_4/METS.xml
@@ -9,25 +9,25 @@
     <amdSec>
         <digiprovMD ID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4782"
-                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="cc5466acf1e5743f9362acd8a51bc2b4"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="10630"
+                CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="39e90875cf38eb0e9015bd806bdd3293"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>
 
     <fileSec ID="uuid-170f9654-bf8d-45df-8451-48d6203b9f03">
         <fileGrp USE="data" ID="uuid-d020d7d1-f258-40af-8788-04cf62a0032b">
-            <file ID="uuid-0ee31ffa-2229-11ed-8b87-7e92631d7d28" MIMETYPE="model/obj" SIZE="1735648"
+            <file ID="uuid-0ee31ffa-2229-11ed-8b87-7e92631d7d28" MIMETYPE="model/obj" SIZE="0"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="d41d8cd98f00b204e9800998ecf8427e"
                 CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./data/qv3bz95m19_REF_OBJ.OBJ" />
             </file>
-            <file ID="uuid-1736bcfc-2229-11ed-814f-7e92631d7d28" MIMETYPE="model/mtl" SIZE="1735648"
+            <file ID="uuid-1736bcfc-2229-11ed-814f-7e92631d7d28" MIMETYPE="model/mtl" SIZE="0"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="d41d8cd98f00b204e9800998ecf8427e"
                 CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./data/qv3bz95m19_REF_MTL.MTL" />
             </file>
-            <file ID="uuid-1db5e9fe-2229-11ed-90ca-7e92631d7d28" MIMETYPE="image/bmp" SIZE="1735648"
+            <file ID="uuid-1db5e9fe-2229-11ed-90ca-7e92631d7d28" MIMETYPE="image/bmp" SIZE="0"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="d41d8cd98f00b204e9800998ecf8427e"
                 CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./data/qv3bz95m19_REF_BMP.BMP" />

--- a/2.1/basic_deec5d89-3024-4cbd-afcd-e18af4ad33ec/uuid-de61d4af-d19c-4cc7-864d-55573875b438/METS.xml
+++ b/2.1/basic_deec5d89-3024-4cbd-afcd-e18af4ad33ec/uuid-de61d4af-d19c-4cc7-864d-55573875b438/METS.xml
@@ -21,20 +21,20 @@
 
     <!-- ref to descriptive metadata about IE -->
     <dmdSec ID="uuid-4d18fdda-a20c-4410-9fce-30c6bff14f50">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc+schema.xml" MIMETYPE="text/xml" SIZE="729" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="2ded6a46ec99021298623a81f33a606f" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc+schema.xml" MIMETYPE="text/xml" SIZE="1046" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="2ded6a46ec99021298623a81f33a606f" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->
     <amdSec>
         <digiprovMD ID="uuid-e2dcd7c5-5fad-4bcd-a7c7-762b0be75d0f">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="1437" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="23cc828ed22090e0ab1ca7bae13afac4" CHECKSUMTYPE="MD5"/>
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="1501" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="23cc828ed22090e0ab1ca7bae13afac4" CHECKSUMTYPE="MD5"/>
         </digiprovMD>
     </amdSec>
 
     <!-- file section -->
     <fileSec ID="uuid-b8e1e265-7003-42e4-8c33-3fc95122d4f4">
         <fileGrp USE="Representations/representation_1" ID="uuid-6ec1cf49-0d4a-413d-9170-4dcb4bd09473">
-            <file ID="uuid-ba89c101-109a-4fe3-a4ed-0c276b20e14c" MIMETYPE="text/xml" SIZE="2240" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="7dddde55e243ea923fc94c0ed86e08ef" CHECKSUMTYPE="MD5">
+            <file ID="uuid-ba89c101-109a-4fe3-a4ed-0c276b20e14c" MIMETYPE="text/xml" SIZE="2352" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="2e1506a1a108317b793e2b591a232220" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="representations/representation_1/METS.xml"/>
             </file>
         </fileGrp>

--- a/2.1/basic_deec5d89-3024-4cbd-afcd-e18af4ad33ec/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_1/METS.xml
+++ b/2.1/basic_deec5d89-3024-4cbd-afcd-e18af4ad33ec/uuid-de61d4af-d19c-4cc7-864d-55573875b438/representations/representation_1/METS.xml
@@ -5,7 +5,7 @@
 
     <amdSec>
         <digiprovMD ID="uuid-f7972ff5-599e-4f60-8b7e-8bbf4e035482">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4782" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="fee8b7594217d234cb5988753123a8b7" CHECKSUMTYPE="MD5" />
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4790" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="fee8b7594217d234cb5988753123a8b7" CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>
 

--- a/2.1/ftp_sidecar_904c6e86-d36a-4630-897b-bb560ce4b690/uuid-904c6e86-d36a-4630-897b-bb560ce4b690/METS.xml
+++ b/2.1/ftp_sidecar_904c6e86-d36a-4630-897b-bb560ce4b690/uuid-904c6e86-d36a-4630-897b-bb560ce4b690/METS.xml
@@ -20,18 +20,18 @@
     </metsHdr>
 
     <dmdSec ID="uuid-25c076a4-39e5-429b-a495-1c0a7dff5b04" CREATED="2022-04-08T09:29:15.014+02:00">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="./metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="9505" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="913c7e09c0c3ee078c89a5d6adba8e71" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="./metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="9752" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="913c7e09c0c3ee078c89a5d6adba8e71" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <amdSec>
         <digiprovMD ID="uuid-056d1289-c015-4815-b91c-78dcbdbdf9aa">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="5695" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="3d4f281f993681bfb3c50a46c7655158" CHECKSUMTYPE="MD5"/>
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="5661" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="3d4f281f993681bfb3c50a46c7655158" CHECKSUMTYPE="MD5"/>
         </digiprovMD>
     </amdSec>
 
     <fileSec ID="uuid-8121ea13-cdf2-47e5-9671-7046609b1ddc">
         <fileGrp USE="Representations/representation_1" ID="uuid-f98a1920-e98d-4e3a-a80e-80525fc57bf8">
-            <file ID="uuid-489d422b-4195-4545-9920-b1cd6fecbd02" MIMETYPE="text/xml" SIZE="2326" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="b94f797b8279933c3f5592f002cdc06a" CHECKSUMTYPE="MD5">
+            <file ID="uuid-489d422b-4195-4545-9920-b1cd6fecbd02" MIMETYPE="text/xml" SIZE="2366" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="c5071cbe191187f18e5500382532536f" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_1/METS.xml"/>
             </file>
         </fileGrp>

--- a/2.1/ftp_sidecar_904c6e86-d36a-4630-897b-bb560ce4b690/uuid-904c6e86-d36a-4630-897b-bb560ce4b690/representations/representation_1/METS.xml
+++ b/2.1/ftp_sidecar_904c6e86-d36a-4630-897b-bb560ce4b690/uuid-904c6e86-d36a-4630-897b-bb560ce4b690/representations/representation_1/METS.xml
@@ -5,7 +5,7 @@
 
     <amdSec>
         <digiprovMD ID="uuid-1e1a1ecb-2f32-477e-b0d7-d5e838091ce4">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="3958" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="52220341d774c03ed250b76cd32bcd92" CHECKSUMTYPE="MD5" />
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4200" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="52220341d774c03ed250b76cd32bcd92" CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>
 

--- a/2.1/newspaper_c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/uuid-c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/METS.xml
+++ b/2.1/newspaper_c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/uuid-c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/METS.xml
@@ -21,25 +21,25 @@
 
     <!-- ref to descriptive metadata about IE (newspaper edition): MODS format -->
     <dmdSec ID="uuid-a4440db5-87f9-45af-819a-b966ca7f10fa" CREATED="2022-02-16T10:01:15.014+02:00">
-        <mdRef LOCTYPE="URL" MDTYPE="MODS" xlink:type="simple" xlink:href="./metadata/descriptive/mods.xml" MIMETYPE="text/xml" SIZE="2023" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="fa550921e1f03d56d96a52c4bd189422" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="MODS" xlink:type="simple" xlink:href="./metadata/descriptive/mods.xml" MIMETYPE="text/xml" SIZE="2056" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="fa550921e1f03d56d96a52c4bd189422" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/package -->
     <amdSec>
         <digiprovMD ID="uuid-06efacfd-cc03-4e8f-b98a-e17b9e7eee1e">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="3797" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="5a685a58f764f51cd77d9f17123fb9ed" CHECKSUMTYPE="MD5"/>
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="4525" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="5a685a58f764f51cd77d9f17123fb9ed" CHECKSUMTYPE="MD5"/>
         </digiprovMD>
     </amdSec>
 
     <!-- file section -->
     <fileSec ID="uuid-32e915fd-1c5d-40a9-91fc-c936f2ca54ef">
         <fileGrp USE="Representations/representation_1" ID="uuid-ea8fbe74-9298-4d56-8a64-338d835a902c">
-            <file ID="uuid-7eecb0ea-d63b-4f01-880d-387e4bae5273" MIMETYPE="text/xml" SIZE="3860" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="f4795cf35f4e91aae82bf65ab19f2473" CHECKSUMTYPE="MD5">
+            <file ID="uuid-7eecb0ea-d63b-4f01-880d-387e4bae5273" MIMETYPE="text/xml" SIZE="3982" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="5c8af047d56168a73211995c10321ebb" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_1/METS.xml"/>
             </file>
         </fileGrp>
         <fileGrp USE="Representations/representation_2" ID="uuid-ad3753a4-9b6c-4993-b954-037cd8555f70">
-            <file ID="uuid-08d65d55-fa53-440e-ae2d-59897eabde11" MIMETYPE="text/xml" SIZE="3709" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="4fb38b408c2626d657d6d39f3dcbae9d" CHECKSUMTYPE="MD5">
+            <file ID="uuid-08d65d55-fa53-440e-ae2d-59897eabde11" MIMETYPE="text/xml" SIZE="3831" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="9c964d3e325ddbc2a551599b040d4a16" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_2/METS.xml"/>
             </file>
         </fileGrp>

--- a/2.1/newspaper_c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/uuid-c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/representations/representation_1/METS.xml
+++ b/2.1/newspaper_c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/uuid-c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/representations/representation_1/METS.xml
@@ -10,7 +10,7 @@
     <amdSec>
         <digiprovMD ID="uuid-572c2067-c1de-4206-b33c-7eae7301a36d">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="13544"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="13568"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="366b7ee983d6f47ffd920e8e162715a5"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>

--- a/2.1/newspaper_c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/uuid-c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/representations/representation_2/METS.xml
+++ b/2.1/newspaper_c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/uuid-c44a0b0d-6e2f-4af2-9dab-3a9d447288d0/representations/representation_2/METS.xml
@@ -5,7 +5,7 @@
 
     <amdSec>
         <digiprovMD ID="uuid-281dbc55-8250-4e54-a490-6cdf30880589">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="13586" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="c310cb8e3d9c7485aaff3d43ed17dc4d" CHECKSUMTYPE="MD5" />
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="13610" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="c310cb8e3d9c7485aaff3d43ed17dc4d" CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>
 

--- a/2.1/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/uuid-ebe47259-8f23-4a2d-bf49-55ae1d855393/METS.xml
+++ b/2.1/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/uuid-ebe47259-8f23-4a2d-bf49-55ae1d855393/METS.xml
@@ -21,30 +21,30 @@
 
     <!-- ref to descriptive metadata about IE (newspaper edition): MODS format -->
     <dmdSec ID="uuid-a4440db5-87f9-45af-819a-b966ca7f10fa" CREATED="2022-02-16T10:01:15.014+02:00">
-        <mdRef LOCTYPE="URL" MDTYPE="MODS" xlink:type="simple" xlink:href="./metadata/descriptive/mods.xml" MIMETYPE="text/xml" SIZE="2023" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="53eaf9cfc0cf9ba3f147f196823eb3ff" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="MODS" xlink:type="simple" xlink:href="./metadata/descriptive/mods.xml" MIMETYPE="text/xml" SIZE="2056" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="53eaf9cfc0cf9ba3f147f196823eb3ff" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/package -->
     <amdSec>
         <digiprovMD ID="uuid-06efacfd-cc03-4e8f-b98a-e17b9e7eee1e">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="6365" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="aa95803664951491c015b64a3c6346cd" CHECKSUMTYPE="MD5"/>
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="7438" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="aa95803664951491c015b64a3c6346cd" CHECKSUMTYPE="MD5"/>
         </digiprovMD>
     </amdSec>
 
     <!-- file section -->
     <fileSec ID="uuid-32e915fd-1c5d-40a9-91fc-c936f2ca54ef">
         <fileGrp USE="Representations/representation_1" ID="uuid-ea8fbe74-9298-4d56-8a64-338d835a902c">
-            <file ID="uuid-7eecb0ea-d63b-4f01-880d-387e4bae5273" MIMETYPE="text/xml" SIZE="3812" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="5c5a4b3e4d219d04f612cd8495299687" CHECKSUMTYPE="MD5">
+            <file ID="uuid-7eecb0ea-d63b-4f01-880d-387e4bae5273" MIMETYPE="text/xml" SIZE="3983" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="72f754a28a61a748064e2f4feb025e94" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_1/METS.xml"/>
             </file>
         </fileGrp>
         <fileGrp USE="Representations/representation_2" ID="uuid-ad3753a4-9b6c-4993-b954-037cd8555f70">
-            <file ID="uuid-08d65d55-fa53-440e-ae2d-59897eabde11" MIMETYPE="text/xml" SIZE="3709" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="23302eaf870cb76623a388b9968b8f40" CHECKSUMTYPE="MD5">
+            <file ID="uuid-08d65d55-fa53-440e-ae2d-59897eabde11" MIMETYPE="text/xml" SIZE="3856" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="c040514eb27598a64e727fe7794c486f" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_2/METS.xml"/>
             </file>
         </fileGrp>
         <fileGrp USE="Representations/representation_3" ID="uuid-f5589a35-41e8-4411-a7b3-845edd393d84">
-            <file ID="uuid-e92d7759-96f7-44a5-903e-e829628e99a3" MIMETYPE="text/xml" SIZE="2352" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="bf78611b9e97ffb02c014d7db4942135" CHECKSUMTYPE="MD5">
+            <file ID="uuid-e92d7759-96f7-44a5-903e-e829628e99a3" MIMETYPE="text/xml" SIZE="2499" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="cae6a9d32a58da5238ce1fb5951389f7" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_3/METS.xml"/>
             </file>
         </fileGrp>

--- a/2.1/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/uuid-ebe47259-8f23-4a2d-bf49-55ae1d855393/representations/representation_1/METS.xml
+++ b/2.1/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/uuid-ebe47259-8f23-4a2d-bf49-55ae1d855393/representations/representation_1/METS.xml
@@ -10,7 +10,7 @@
     <amdSec>
         <digiprovMD ID="uuid-572c2067-c1de-4206-b33c-7eae7301a36d">
             <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple"
-                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="13544"
+                xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="13568"
                 CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="366b7ee983d6f47ffd920e8e162715a5"
                 CHECKSUMTYPE="MD5" />
         </digiprovMD>

--- a/2.1/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/uuid-ebe47259-8f23-4a2d-bf49-55ae1d855393/representations/representation_2/METS.xml
+++ b/2.1/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/uuid-ebe47259-8f23-4a2d-bf49-55ae1d855393/representations/representation_2/METS.xml
@@ -5,7 +5,7 @@
 
     <amdSec>
         <digiprovMD ID="uuid-281dbc55-8250-4e54-a490-6cdf30880589">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="13586" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="c310cb8e3d9c7485aaff3d43ed17dc4d" CHECKSUMTYPE="MD5" />
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="13610" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="c310cb8e3d9c7485aaff3d43ed17dc4d" CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>
 

--- a/2.1/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/uuid-ebe47259-8f23-4a2d-bf49-55ae1d855393/representations/representation_3/METS.xml
+++ b/2.1/newspaper_tiff_alto_pdf_ebe47259-8f23-4a2d-bf49-55ae1d855393/uuid-ebe47259-8f23-4a2d-bf49-55ae1d855393/representations/representation_3/METS.xml
@@ -5,7 +5,7 @@
 
     <amdSec>
         <digiprovMD ID="uuid-0fe3be01-ec81-4623-a376-f6b836575a82">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="7386" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="e8a7925d3284fc0b3ecfeadb3e5d52c3" CHECKSUMTYPE="MD5" />
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="7394" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="e8a7925d3284fc0b3ecfeadb3e5d52c3" CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>
 

--- a/2.1/subtitles_d3e1a978-3dd8-4b46-9314-d9189a1c94c6/uuid-508fb4ed-6321-4308-a118-6babd90a61d2/METS.xml
+++ b/2.1/subtitles_d3e1a978-3dd8-4b46-9314-d9189a1c94c6/uuid-508fb4ed-6321-4308-a118-6babd90a61d2/METS.xml
@@ -21,20 +21,20 @@
 
     <!-- ref to descriptive metadata about IE -->
     <dmdSec ID="uuid-f1fdfc02-22e3-4a0c-bcf5-3901db9fbb05" CREATED="2022-02-16T10:01:15.014+02:00">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="./metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="998" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="904464d54da19ec7e324f8e47d88f1a9" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="./metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="2779" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="904464d54da19ec7e324f8e47d88f1a9" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/package -->
     <amdSec>
         <digiprovMD ID="uuid-e06159c9-0133-49d5-a0a8-46c6e774cfac">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="1635" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="70013493d23a7c3d32b9fadd48729372" CHECKSUMTYPE="MD5"/>
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="1706" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="70013493d23a7c3d32b9fadd48729372" CHECKSUMTYPE="MD5"/>
         </digiprovMD>
     </amdSec>
 
     <!-- file section -->
     <fileSec ID="uuid-934e7c04-e411-459d-a552-5c88f6e4e7d4">
         <fileGrp USE="Representations/representation_1" ID="uuid-14138e4b-645b-41c4-ba17-adeac62e773c">
-            <file ID="uuid-ae19db1b-51da-41e4-8f86-592acc8b7571" MIMETYPE="text/xml" SIZE="2708" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="32e50c4b3fe7d59ed55e21808032abff" CHECKSUMTYPE="MD5">
+            <file ID="uuid-ae19db1b-51da-41e4-8f86-592acc8b7571" MIMETYPE="text/xml" SIZE="2837" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="33c54a57284dabf881bb2943bef0e2d0" CHECKSUMTYPE="MD5">
                 <FLocat LOCTYPE="URL" xlink:type="simple" xlink:href="./representations/representation_1/METS.xml"/>
             </file>
         </fileGrp>

--- a/2.1/subtitles_d3e1a978-3dd8-4b46-9314-d9189a1c94c6/uuid-508fb4ed-6321-4308-a118-6babd90a61d2/representations/representation_1/METS.xml
+++ b/2.1/subtitles_d3e1a978-3dd8-4b46-9314-d9189a1c94c6/uuid-508fb4ed-6321-4308-a118-6babd90a61d2/representations/representation_1/METS.xml
@@ -5,7 +5,7 @@
 
     <amdSec>
         <digiprovMD ID="uuid-983b63b3-9e62-4cfa-b07e-2f2c2410db44">
-            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="9194" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="91863714db43823ced88d96cca55fd96" CHECKSUMTYPE="MD5" />
+            <mdRef LOCTYPE="URL" MDTYPE="PREMIS" xlink:type="simple" xlink:href="./metadata/preservation/premis.xml" MIMETYPE="text/xml" SIZE="9210" CREATED="2022-02-16T10:02:37.009+02:00" CHECKSUM="91863714db43823ced88d96cca55fd96" CHECKSUMTYPE="MD5" />
         </digiprovMD>
     </amdSec>
 


### PR DESCRIPTION
The validator gives some errors still:
- It can't find the dc+schema.xml files
- `@TYPE="OTHER"` is not seen as valid